### PR TITLE
Add support for module conditions and map contents

### DIFF
--- a/lua/autorun/server/sv_downloader_init.lua
+++ b/lua/autorun/server/sv_downloader_init.lua
@@ -31,10 +31,28 @@ if not file.Exists(context.dataFolder, "DATA") then
     file.CreateDir(context.dataFolder)
 end
 
-for _, downloaderModule in ipairs(modules) do
+local function ExecuteModule(index)
+    local downloaderModule = modules[index]
+
+    if downloaderModule.Condition then
+        if not downloaderModule:Condition(context) then
+            timer.Simple(0.2, function()
+                ExecuteModule(index)
+            end)
+
+            return
+        end
+    end
+
     if downloaderModule.Run then
         downloaderModule:Run(context)
     end
+
+    if modules[index + 1] then
+        ExecuteModule(index + 1)
+    end
 end
+
+ExecuteModule(1)
 
 -- Garbage collection will clean everything by itself after execution

--- a/lua/autorun/server/sv_downloader_init.lua
+++ b/lua/autorun/server/sv_downloader_init.lua
@@ -19,6 +19,7 @@ end)
 
 local context = {
     dataFolder = "uwd",
+    mapInfoFinished = false,
     addons = engine.GetAddons(),
     ignoreResources = {},
     usingAddons = {},

--- a/lua/downloader/map_scanner.lua
+++ b/lua/downloader/map_scanner.lua
@@ -5,9 +5,11 @@ local currentMap = game.GetMap()
 
 function MODULE:Run(context)
     local foundMap = false
+    local addonsByWsid = {}
 
     for _, addon in ipairs(context.addons) do
         local isMap = addon.tags and addon.tags:lower():find("map")
+        addonsByWsid[addon.wsid] = addon
 
         if isMap then
             if file.Exists("maps/" .. currentMap  .. ".bsp", addon.title) then
@@ -18,7 +20,9 @@ function MODULE:Run(context)
                 http.Fetch('https://steamcommunity.com/sharedfiles/filedetails/?id=' .. addon.wsid,
                 function(body)
                     for wsid in string.gmatch(body, '<a href="https://steamcommunity%.com/workshop/filedetails/%?id=(%d+)" target="_blank">') do
-                        context.ignoreResources[wsid] = false
+                        if addonsByWsid[wsid] then
+                            table.insert(context.usingAddons, addonsByWsid[wsid])
+                        end
                     end
                     context.mapInfoFinished = true
                 end,

--- a/lua/downloader/map_scanner.lua
+++ b/lua/downloader/map_scanner.lua
@@ -4,17 +4,36 @@ MODULE.Order = 4
 local currentMap = game.GetMap()
 
 function MODULE:Run(context)
+    local foundMap = false
+
     for _, addon in ipairs(context.addons) do
         local isMap = addon.tags and addon.tags:lower():find("map")
 
         if isMap then
             if file.Exists("maps/" .. currentMap  .. ".bsp", addon.title) then
+                foundMap = true
+
                 table.insert(context.usingAddons, addon)
+
+                http.Fetch('https://steamcommunity.com/sharedfiles/filedetails/?id=' .. addon.wsid,
+                function(body)
+                    for wsid in string.gmatch(body, '<a href="https://steamcommunity%.com/workshop/filedetails/%?id=(%d+)" target="_blank">') do
+                        context.ignoreResources[wsid] = false
+                    end
+                    context.mapInfoFinished = true
+                end,
+                function()
+                    context.mapInfoFinished = true
+                end)
             end
 
             -- Is probably a map addon, resources should be ignored
             context.ignoreResources[addon.wsid] = true
         end
+    end
+
+    if not foundMap then
+        context.mapInfoFinished = true
     end
 end
 

--- a/lua/downloader/resource_scanner.lua
+++ b/lua/downloader/resource_scanner.lua
@@ -4,6 +4,10 @@ MODULE.Order = 5
 -- Download any gmas with these extensions
 local resourceExtensions = include("downloader/resources.lua")
 
+function MODULE:Condition(context)
+    return context.mapInfoFinished
+end
+
 local function HasUsingResource(currentPath, addonTitle)
     local files, dirs = file.Find(currentPath .. "*", addonTitle)
 


### PR DESCRIPTION
Now modules are able to require states before being executed, allowing us to wait as long as necessary for various tasks to be completed.

Through this mechanism I implemented an http request to obtain a list of addons needed for the current map, which was used to finally add support for map contents - even if they are other maps!

Tests (with special logs):

1) Workshop map with no required contents:
![image](https://user-images.githubusercontent.com/5098527/231948046-480564d0-6dca-46b9-86b5-e14bc9049054.png)

2) Workshop map with required contents:
![image](https://user-images.githubusercontent.com/5098527/231948477-78997721-d715-40c7-b0ad-abb2dd6dee0d.png)

3) Default GMod map:
![image](https://user-images.githubusercontent.com/5098527/231948925-13b0cc15-1668-46a0-a861-6c0532f72571.png)
