### PR TITLE
Add UWD panel - Support for manual addon selections and easy inspections

### DIFF
--- a/lua/autorun/client/cl_downloader_init.lua
+++ b/lua/autorun/client/cl_downloader_init.lua
@@ -229,7 +229,7 @@ function Browser:PopulateList()
     local addons = engine.GetAddons() -- I get the addon names locally instead of sending them through net
     local baseDelayNotFound = 0.05
     local baseDelayFound = 0.015
-    local delay = 0 
+    local delay = 0.3
 
     table.sort(addons, function(a, b) return string.lower(a.title) < string.lower(b.title) end)
 

--- a/lua/autorun/client/cl_downloader_init.lua
+++ b/lua/autorun/client/cl_downloader_init.lua
@@ -496,11 +496,11 @@ function Browser:FilterAddons(selectedValue)
     end)
 end
 
-concommand.Add("uwd_page", function()
+concommand.Add("downloader_page", function()
     steamworks.ViewFile(2214712098)
 end)
 
-concommand.Add("uwd_menu", function()
+concommand.Add("downloader_menu", function()
     if Browser.scanResult then
         Browser:Open()
     else
@@ -511,7 +511,7 @@ end)
 
 local function CPanel(self)
     self:Help("UWD - Install and forget.")
-    self:Button("Open Menu", "uwd_menu")
+    self:Button("Open Menu", "downloader_menu")
     self:ControlHelp("- Fully automatic")
     self:ControlHelp("- Extremely fast")
     self:ControlHelp("- Intelligent addon selection")
@@ -521,7 +521,7 @@ local function CPanel(self)
     self:ControlHelp("- Validates pointshop models")
     self:ControlHelp("- Actually works")
     self:Help("If you find any addons that were not detected, please report them to us!")
-    self:Button("Report Error", "uwd_page")
+    self:Button("Report Error", "downloader_page")
 end
 
 hook.Add("PopulateToolMenu", "All hail the menus", function ()

--- a/lua/autorun/client/cl_downloader_init.lua
+++ b/lua/autorun/client/cl_downloader_init.lua
@@ -1,0 +1,544 @@
+if game.SinglePlayer() then
+    return
+end
+
+surface.CreateFont("uwd_panel_font", {
+    font = "Arial",
+    extended = false,
+    size = 12,
+    weight = 500,
+    blursize = 0,
+    scanlines = 0,
+    antialias = true,
+    underline = false,
+    italic = false,
+    strikeout = false,
+    symbol = false,
+    rotary = false,
+    shadow = true,
+    additive = false,
+    outline = false,
+})
+
+local FILTER = {
+    ALL = 0,
+    SELECTED = 1,
+    IGNORED = 2,
+    MANUAL = 3
+}
+
+local Browser = {}
+
+Browser.initialized = false
+
+Browser.cacheFile = "uwd/browser_cache.txt"
+
+Browser.topBar = 25
+Browser.border = 10
+Browser.backgroundColor = Color(255, 255, 255, 255)
+
+Browser.titleBarBackgroundColor = Color(37, 37, 37, 255)
+
+Browser.iconSize = 150
+Browser.iconTextHeight = 25
+Browser.controlButtonsWidth = 100
+
+Browser.commonHeight = 25
+Browser.scrollBarWidth = 15
+Browser.filterWidth = 125
+
+Browser.maxIconsWidth = math.floor((ScrW() * 0.8) / Browser.iconSize)
+Browser.maxIconsHeight = math.floor((ScrH() * 0.9) / Browser.iconSize)
+
+Browser.width = Browser.maxIconsWidth * Browser.iconSize + Browser.maxIconsWidth * Browser.border + Browser.border + Browser.scrollBarWidth
+Browser.height = Browser.maxIconsHeight * Browser.iconSize + Browser.maxIconsHeight * Browser.border + Browser.border + Browser.topBar
+
+Browser.iconBackgroundColor = {
+    ignored = Color(246, 255, 228),
+    selected = Color(188, 235, 96),
+    restart = Color(255, 130, 130),
+    rejoin = Color(255, 255, 71)
+}
+
+function Browser:LoadCache()
+    local cache = file.Read(self.cacheFile, "DATA")
+    self.cache = util.JSONToTable(cache or "{}")
+end
+
+function Browser:SaveCache()
+    file.Write(self.cacheFile, util.TableToJSON(self.cache))
+end
+
+function Browser:Open(scanResult)
+    if scanResult then
+        self.scanResult = scanResult
+    end
+
+    if self.initialized then
+        self.frame:SetVisible(true)
+    else
+        self:SetupBasePanels()
+        self:LoadCache()
+        self:PopulateList()
+        self.initialized = true
+    end
+end
+
+net.Receive("uwd_exchange_scan_result", function(len, ply)
+    Browser:Open(util.JSONToTable(net.ReadString()))
+end)
+
+function Browser:SetupBasePanels()
+    if self.initialized then return end
+
+    self.frame = vgui.Create("DFrame")
+    self.frame:SetTitle("Ultimate Workshop Downloader")
+    self.frame:SetSize(self.width, self.height)
+    self.frame:SetDeleteOnClose(false)
+    self.frame:SetIcon("games/16/all.png")
+    self.frame:SetVisible(true)
+    self.frame:Center()
+    self.frame:MakePopup()
+    function Browser:Close()
+        self:SetVisible(false)
+    end
+
+    -- Element properties
+
+    local panelInfo = {
+        width = self.frame:GetWide(),
+        height = self.frame:GetTall() - self.topBar,
+        x = 0,
+        y = self.topBar
+    }
+
+    local panelTitleInfo = {
+        width = self.frame:GetWide(),
+        height = self.topBar,
+        x = 0,
+        y = 0
+    }
+
+    local filterInfo = {
+        width = self.filterWidth,
+        height = self.commonHeight,
+        x = self.frame:GetWide() - self.filterWidth - self.controlButtonsWidth,
+        y = 0
+    }
+
+    local addonsScrollInfo = {
+        width = self.frame:GetWide() - self.border,
+        height = self.frame:GetTall() - self.topBar - self.border * 2,
+        x = self.border,
+        y = self.border
+    }
+
+    -- Main area
+    self.panel = vgui.Create("DPanel", self.frame)
+    self.panel:SetSize(panelInfo.width, panelInfo.height)
+    self.panel:SetPos(panelInfo.x, panelInfo.y)
+    self.panel:SetBackgroundColor(Browser.backgroundColor)
+
+    -- Alert text
+    self.alertTextBackground = vgui.Create("DPanel", self.frame)
+    self.alertTextBackground:SetPos(0, self.iconSize - self.iconTextHeight)
+    self.alertTextBackground:SetBackgroundColor(iconBackgroundColor)
+    self.alertTextBackground:SetVisible(false)
+
+    self.alertText = vgui.Create("DLabel", self.alertTextBackground)
+    self.alertText:SetPos(5, 5)
+    self.alertText:SetColor(Color(0, 0, 0, 255))
+
+    -- Icons list
+    self.addonsScroll = vgui.Create("DScrollPanel", self.panel)
+    self.addonsScroll:SetSize(addonsScrollInfo.width, addonsScrollInfo.height)
+    self.addonsScroll:SetPos(addonsScrollInfo.x, addonsScrollInfo.y)
+
+    self.addonsList = vgui.Create("DIconLayout", self.addonsScroll)
+    self.addonsList:Dock(FILL)
+    self.addonsList:SetSpaceY(self.border)
+    self.addonsList:SetSpaceX(self.border)
+    self.addonsList:IsHovered()
+    self.addonsList.void = {} -- Used to hide elements when filtering
+
+    -- Filter
+    self.filter = vgui.Create("DComboBox", self.frame)
+    self.filter:SetSize(filterInfo.width, filterInfo.height)
+    self.filter:SetPos(filterInfo.x, filterInfo.y)
+    self.filter:AddChoice("All", FILTER.ALL, false, "icon16/box.png")
+    self.filter:AddChoice("Selected", FILTER.SELECTED, false, "icon16/accept.png")
+    self.filter:AddChoice("Ignored", FILTER.IGNORED, false, "icon16/delete.png")
+    self.filter:AddChoice("Manual", FILTER.MANUAL, false, "icon16/pencil.png")
+    self.filter:SetText("All")
+    self.filter.OnSelect = function(self, index, value)
+        Browser:FilterAddons(self:GetOptionData(index))
+    end
+end
+
+-- An alert message saying what's needed to fully apply the changes
+function Browser:SetAlertText()
+    -- Check if the message is needed and show or hide the panel
+    local found
+    for wsid, resultInfo in pairs(self.scanResult) do
+        if resultInfo.manual ~= nil then
+            if resultInfo.manual == true then
+                if not self.scanResult[wsid].selected then
+                    found = "Select"
+                end
+            else
+                found = "Ignore"
+                break
+            end
+        end
+    end
+
+    if not found then
+        if self.alertTextBackground:IsVisible() then
+            self.alertTextBackground:SetVisible(false)
+        end
+
+        return
+    end
+
+    if not self.alertTextBackground:IsVisible() then
+        self.alertTextBackground:SetVisible(true)
+    end
+
+    -- Set the correct message / background color and resize the element
+    if found == "Select" then
+        self.alertText:SetText("You need to rejoin the server to download the new selected addons.")
+        self.alertTextBackground:SetBackgroundColor(self.iconBackgroundColor.rejoin)
+    elseif found == "Ignore" then
+        self.alertText:SetText("The server needs to be restarted to remove new ignored or previously selected addons.")
+        self.alertTextBackground:SetBackgroundColor(self.iconBackgroundColor.restart)
+    end
+    self.alertText:SizeToContents()
+
+    self.alertTextBackground:SizeToChildren(true, true)
+    local alertBackW = self.alertTextBackground:GetWide() + 5
+
+    local alertTextInfo = {
+        width = alertBackW,
+        height = self.commonHeight,
+        x = self.frame:GetWide()/2 - alertBackW/2,
+        y = 0
+    }
+
+    self.alertTextBackground:SetSize(alertTextInfo.width, alertTextInfo.height)
+    self.alertTextBackground:SetPos(alertTextInfo.x, alertTextInfo.y)
+end
+
+-- Fill up the menu with the addons, always sorted by name
+function Browser:PopulateList()
+    local addons = engine.GetAddons() -- I get the addon names locally instead of sending them through net
+    local baseDelayNotFound = 0.05
+    local baseDelayFound = 0.015
+    local delay = 0 
+
+    table.sort(addons, function(a, b) return string.lower(a.title) < string.lower(b.title) end)
+
+    for k, addonInfo in ipairs(addons) do
+        local wsid = tonumber(addonInfo.wsid) -- Note: loading the cache from a json always converts the wsid to number
+
+        if not self.scanResult[wsid] then continue end -- Ignore unmounted addons
+
+        local iconBackgroundColor
+        if self.scanResult[wsid].cachedManual == nil and self.scanResult[wsid].selected or self.scanResult[wsid].cachedManual then
+            iconBackgroundColor = self.iconBackgroundColor.selected
+        else
+            iconBackgroundColor = self.iconBackgroundColor.ignored
+        end
+
+        local iconArea = self.addonsList:Add(vgui.Create("DPanel"))
+        iconArea:SetSize(self.iconSize, self.iconSize)
+        iconArea:SetBackgroundColor(iconBackgroundColor)
+
+        self.scanResult[wsid].iconArea = iconArea
+
+        local contentSize = self.iconSize * 0.94
+        local contentBorder = self.iconSize * 0.06 / 2
+
+        local iconBackground = vgui.Create("DPanel", iconArea)
+        iconBackground:SetPos(contentBorder, contentBorder)
+        iconBackground:SetSize(contentSize, contentSize)
+
+        local iconTitleBackground = vgui.Create("DPanel", iconArea)
+        iconTitleBackground:SetSize(self.iconSize, self.iconTextHeight)
+        iconTitleBackground:SetBackgroundColor(iconBackgroundColor)
+        iconTitleBackground:SetTooltip(addonInfo.title)
+
+        local iconTitle = vgui.Create("DLabel", iconTitleBackground)
+        iconTitle:SetWide(self.iconSize)
+        iconTitle:SetPos(5, 2)
+        iconTitle:SetText(addonInfo.title)
+        iconTitle:SetColor(Color(0, 0, 0, 255))
+
+        local manualAlertBackground = vgui.Create("DPanel", iconArea)
+        manualAlertBackground:SetPos(0, self.iconSize - self.iconTextHeight * 2 - self.border)
+        manualAlertBackground:SetBackgroundColor(iconBackgroundColor)
+
+        local manualAlert = vgui.Create("DLabel", manualAlertBackground)
+        manualAlert:SetPos(5, 5)
+        manualAlert:SetText("Manual")
+        manualAlert:SetColor(Color(0, 0, 0, 255))
+
+        manualAlertBackground:Hide()
+        if self.scanResult[wsid].cachedManual ~= nil and self.scanResult[wsid].cachedManual ~= self.scanResult[wsid].selected then
+            manualAlertBackground:Show()
+        end
+
+        manualAlert:SizeToContents()
+
+        manualAlertBackground:SizeToChildren(true, true)
+        local manualBackW = manualAlertBackground:GetWide()
+        manualAlertBackground:SetSize(manualBackW + 5, self.commonHeight)
+
+        local iconTypeBackground = vgui.Create("DPanel", iconArea)
+        iconTypeBackground:SetPos(0, self.iconSize - self.iconTextHeight)
+        iconTypeBackground:SetBackgroundColor(iconBackgroundColor)
+
+        local iconType = vgui.Create("DLabel", iconTypeBackground)
+        iconType:SetPos(5, 5)
+        iconType:SetText(self.scanResult[wsid].type)
+        iconType:SetColor(Color(0, 0, 0, 255))
+        iconType:SizeToContents()
+
+        iconTypeBackground:SizeToChildren(true, true)
+        local typeBackW = iconTypeBackground:GetWide()
+        iconTypeBackground:SetSize(typeBackW + 5, self.commonHeight)
+
+        local icon = vgui.Create("DImageButton", iconBackground)
+        icon:SetSize(contentSize, contentSize)
+        icon:SetPos(0, 0)
+        icon:SetTooltip("Left Click - Toggle | Right Click - Open on Workshop")
+        icon.OnDepressed = function()
+            -- Workshop page
+            if input.IsMouseDown(108) then -- MOUSE_RIGHT
+                steamworks.ViewFile(wsid)
+            -- Toggle selection
+            elseif input.IsMouseDown(107) then -- MOUSE_LEFT
+                if not LocalPlayer():IsAdmin() then return end
+
+                -- Get the initial state
+                local initialState
+                if self.scanResult[wsid].cachedManual ~= nil then
+                    initialState = self.scanResult[wsid].cachedManual
+                else
+                    initialState = self.scanResult[wsid].selected
+                end
+
+                -- Initialize the new manual state
+                if self.scanResult[wsid].manual == nil then
+                    self.scanResult[wsid].manual = not initialState
+                else
+                    self.scanResult[wsid].manual = not self.scanResult[wsid].manual
+                end
+
+                -- Change the Manual panel message and show or hide it
+                if self.scanResult[wsid].cachedManual ~= nil and
+                   self.scanResult[wsid].cachedManual ~= self.scanResult[wsid].selected
+                then
+                    if self.scanResult[wsid].manual == initialState then
+                        manualAlertBackground:Show()
+                    else
+                        manualAlertBackground:Hide()
+                    end
+                else
+                    if self.scanResult[wsid].manual == initialState then
+                        manualAlertBackground:Hide()
+                    else
+                        manualAlertBackground:Show()
+                    end
+                end
+
+                iconType:SizeToContents()
+
+                iconTypeBackground:SizeToChildren(true, true)
+                local backW = iconTypeBackground:GetWide()
+                iconTypeBackground:SetSize(backW + 5, backW + 2)
+
+                -- Change general background colors
+                if self.scanResult[wsid].manual == true then
+                    local backgroundColor
+
+                    if initialState then
+                        backgroundColor = self.iconBackgroundColor.selected
+                    else
+                        backgroundColor = self.iconBackgroundColor.rejoin
+                    end
+
+                    iconArea:SetBackgroundColor(backgroundColor)
+                    iconTitleBackground:SetBackgroundColor(backgroundColor)
+                    iconTypeBackground:SetBackgroundColor(backgroundColor)
+                    manualAlertBackground:SetBackgroundColor(backgroundColor)
+                else
+                    iconArea:SetBackgroundColor(self.iconBackgroundColor.restart)
+                    iconTitleBackground:SetBackgroundColor(self.iconBackgroundColor.restart)
+                    iconTypeBackground:SetBackgroundColor(self.iconBackgroundColor.restart)
+                    manualAlertBackground:SetBackgroundColor(self.iconBackgroundColor.restart)
+                end
+
+                -- Add the alert message to the top of the page saying what's needed to fully apply the changes
+                self:SetAlertText()
+
+                -- Set the new value on the server
+                net.Start("uwd_set_manual_selection")
+                net.WriteString(tostring(wsid))
+                net.WriteBool(self.scanResult[wsid].manual)
+                net.SendToServer()
+            end
+        end
+
+        -- The images will be retrieved from the workshop or from the cache
+        -- while the delay make sure we don't send too many requests neither
+        -- read too much info from the disk at the same time. I save the cache
+        -- every 20 new downloads and when the process is done (given at least
+        -- 1 new image was downloaded)
+        local iteratingNewAddons = 0
+        if self.cache[wsid] and file.Exists(self.cache[wsid], "GAME") then
+            delay = delay + baseDelayFound
+            timer.Simple(delay, function()
+                if IsValid(self.frame) and IsValid(icon) then
+                    local iconMaterial = AddonMaterial(self.cache[wsid])
+                    icon:SetMaterial(iconMaterial)
+                end
+            end)
+        else
+            delay = delay + baseDelayNotFound
+            iteratingNewAddons = iteratingNewAddons + 1
+            timer.Simple(delay, function()
+                steamworks.FileInfo(addonInfo.wsid, function(result)
+                    steamworks.Download(result.previewid, true, function(cachePath)
+                        if IsValid(self.frame) and IsValid(icon) then
+                            local iconMaterial = AddonMaterial(cachePath)
+                            icon:SetMaterial(iconMaterial)
+                            self.cache[wsid] = cachePath
+                        end
+                    end) 
+                end)
+            end)
+        end
+
+        if iteratingNewAddons == 20 or (k == #addons and iteratingNewAddons != 0) then
+            iteratingNewAddons = 0
+            timer.Simple(delay + 1, function()
+                if IsValid(self.frame) then
+                    self:SaveCache()
+                end
+            end)
+        end
+    end
+end
+
+-- Filter the addons by type, always sorted by name
+function Browser:FilterAddons(selectedValue)
+    -- Getting addons
+    local addons = engine.GetAddons()
+
+    table.sort(addons, function(a, b) return string.lower(a.title) < string.lower(b.title) end)
+
+    -- Move all icons to the void and hide them
+    for k, addonInfo in ipairs(addons) do
+        local wsid = tonumber(addonInfo.wsid)
+        local scanInfo = self.scanResult[wsid]
+
+        if not scanInfo then continue end
+
+        if IsValid(scanInfo.iconArea) then
+            scanInfo.iconArea:SetParent(self.addonsList.void)
+            scanInfo.iconArea:Hide()
+        end    
+    end
+
+    -- Move the selected icons back to the panel and make sure they appear
+    for k, addonInfo in ipairs(addons) do
+        local wsid = tonumber(addonInfo.wsid)
+        local scanInfo = self.scanResult[wsid]
+
+        if not scanInfo then continue end
+
+        if IsValid(scanInfo.iconArea) then
+            if selectedValue == FILTER.ALL then
+                scanInfo.iconArea:Show()
+                scanInfo.iconArea:SetParent(self.addonsList)
+            elseif selectedValue == FILTER.SELECTED then
+                if scanInfo.manual == nil and scanInfo.cachedManual == nil and scanInfo.selected == true or
+                   scanInfo.manual == nil and scanInfo.cachedManual == true or
+                   scanInfo.manual == true
+                then
+                    scanInfo.iconArea:Show()
+                    scanInfo.iconArea:SetParent(self.addonsList)
+                end
+            elseif selectedValue == FILTER.IGNORED then
+                if scanInfo.manual == nil and scanInfo.cachedManual == nil and scanInfo.selected == false or
+                   scanInfo.manual == nil and scanInfo.cachedManual == false or
+                   scanInfo.manual == false
+                then
+                    scanInfo.iconArea:Show()
+                    scanInfo.iconArea:SetParent(self.addonsList)
+                end
+            elseif selectedValue == FILTER.MANUAL then
+                if scanInfo.manual == nil and scanInfo.cachedManual ~= nil and scanInfo.cachedManual ~= scanInfo.selected or
+                   scanInfo.manual ~= nil and scanInfo.manual ~= scanInfo.selected
+                then
+                    scanInfo.iconArea:Show()
+                    scanInfo.iconArea:SetParent(self.addonsList)
+                end
+            end
+        end  
+    end
+
+    -- Refresh the scroll bar
+    timer.Simple(0.2, function()
+        if IsValid(self.frame) and IsValid(self.addonsScroll) then
+            self.addonsScroll:InvalidateLayout()
+        end
+    end)
+end
+
+concommand.Add("uwd_page", function()
+    steamworks.ViewFile(2214712098)
+end)
+
+concommand.Add("uwd_menu", function()
+    if Browser.scanResult then
+        Browser:Open()
+    else
+        net.Start("uwd_exchange_scan_result")
+        net.SendToServer()
+    end
+end)
+
+local function CPanel(self)
+    self:Help("UWD - Install and forget.")
+    self:Button("Open Menu", "uwd_menu")
+    self:ControlHelp("- Fully automatic")
+    self:ControlHelp("- Extremely fast")
+    self:ControlHelp("- Intelligent addon selection")
+    self:ControlHelp("- For listen and dedicated servers")
+    self:ControlHelp("- Supports legacy addons")
+    self:ControlHelp("- Has an easy yet powerful panel")
+    self:ControlHelp("- Validates pointshop models")
+    self:ControlHelp("- Actually works")
+    self:Help("If you find any addons that were not detected, please report them to us!")
+    self:Button("Report Error", "uwd_page")
+end
+
+hook.Add("PopulateToolMenu", "All hail the menus", function ()
+    spawnmenu.AddToolMenuOption("Utilities", "Ultimate Workshop Downloder", "Addons", "Addons", "", "", CPanel)
+end)
+
+-- Tests
+
+-- if UWD_Test and IsValid(UWD_Test.frame) then
+--     UWD_Test.frame:Remove()
+-- end
+
+-- UWD_Test = Browser
+
+-- if Browser.scanResult then
+--     Browser:Open()
+-- else
+--     net.Start("uwd_exchange_scan_result")
+--     net.SendToServer()
+-- end

--- a/lua/autorun/server/sv_downloader_init.lua
+++ b/lua/autorun/server/sv_downloader_init.lua
@@ -2,6 +2,9 @@ if game.SinglePlayer() then
     return
 end
 
+util.AddNetworkString("uwd_exchange_scan_result")
+util.AddNetworkString("uwd_set_manual_selection")
+
 local files = file.Find("downloader/*.lua", "LUA")
 local modules = {}
 
@@ -24,12 +27,45 @@ local context = {
     usingAddons = {},
     started = SysTime(),
     gamemodeAddons = {},
-    addonsToCache = {}
+    addonsToCache = {},
+    manualAddons = {},
+    scanResult = {}
 }
 
 if not file.Exists(context.dataFolder, "DATA") then
     file.CreateDir(context.dataFolder)
 end
+
+net.Receive("uwd_exchange_scan_result", function(len, ply)
+    local scanResult = table.Copy(context.scanResult)
+
+    for wsid, value in pairs(context.manualAddons) do
+        if scanResult[wsid] then
+            scanResult[wsid].cachedManual = value
+        end
+    end
+
+    scanResult = util.TableToJSON(scanResult)
+
+    net.Start("uwd_exchange_scan_result")
+    net.WriteString(scanResult) -- Lazy
+    net.Send(ply)
+end)
+
+net.Receive("uwd_set_manual_selection", function(len, ply)
+    if not ply:IsAdmin() then return end
+
+    local wsid = tonumber(net.ReadString())
+    local value = net.ReadBool()
+
+    local cacheFile = context.dataFolder .. "/workshop_cache.txt"
+    local cache = util.JSONToTable(file.Read(cacheFile, "DATA") or "{}") or {}
+
+    cache[wsid] = cache[wsid] or {}
+    cache[wsid].manual = value
+
+    file.Write(cacheFile, util.TableToJSON(cache))
+end)
 
 for _, downloaderModule in ipairs(modules) do
     if downloaderModule.Run then

--- a/lua/autorun/server/sv_downloader_init.lua
+++ b/lua/autorun/server/sv_downloader_init.lua
@@ -36,41 +36,10 @@ if not file.Exists(context.dataFolder, "DATA") then
     file.CreateDir(context.dataFolder)
 end
 
-net.Receive("uwd_exchange_scan_result", function(len, ply)
-    local scanResult = table.Copy(context.scanResult)
-
-    for wsid, value in pairs(context.manualAddons) do
-        if scanResult[wsid] then
-            scanResult[wsid].cachedManual = value
-        end
-    end
-
-    scanResult = util.TableToJSON(scanResult)
-
-    net.Start("uwd_exchange_scan_result")
-    net.WriteString(scanResult) -- Lazy
-    net.Send(ply)
-end)
-
-net.Receive("uwd_set_manual_selection", function(len, ply)
-    if not ply:IsAdmin() then return end
-
-    local wsid = tonumber(net.ReadString())
-    local value = net.ReadBool()
-
-    local cacheFile = context.dataFolder .. "/workshop_cache.txt"
-    local cache = util.JSONToTable(file.Read(cacheFile, "DATA") or "{}") or {}
-
-    cache[wsid] = cache[wsid] or {}
-    cache[wsid].manual = value
-
-    file.Write(cacheFile, util.TableToJSON(cache))
-end)
-
 for _, downloaderModule in ipairs(modules) do
     if downloaderModule.Run then
         downloaderModule:Run(context)
     end
 end
 
--- Garbage collection will clean everything by itself after execution
+-- Garbage collection will clean the context and other local vars by itself after execution

--- a/lua/downloader/cache_load.lua
+++ b/lua/downloader/cache_load.lua
@@ -14,21 +14,14 @@ function MODULE:Run(context)
             if scanned.hasResource then
                 table.insert(context.usingAddons, addon)
                 context.addonsToCache[addon.wsid] = true
+                context.scanResult[addon.wsid] = { selected = true, type = "Resources" }
+            else
+                context.scanResult[addon.wsid] = { selected = false, type = "Lua" }
             end
 
             context.ignoreResources[addon.wsid] = true
             context.gamemodeAddons[addon.wsid] = scanned.isGamemode
             context.manualAddons[addon.wsid] = scanned.manual
-
-            if scanned.scanResult then -- Compatibility with older caches
-                context.scanResult[addon.wsid] = scanned.scanResult
-            else
-                if scanned.hasResource then
-                    context.scanResult[addon.wsid] = { selected = true, type = "Resources" }
-                else
-                    context.scanResult[addon.wsid] = { selected = false, type = "Lua" }
-                end
-            end
         end
     end
 

--- a/lua/downloader/cache_load.lua
+++ b/lua/downloader/cache_load.lua
@@ -2,7 +2,6 @@ local MODULE = {}
 MODULE.Order = 2
 
 function MODULE:Run(context)
-    -- cache = { [number wsid] = { bool hasResource, string updated }, ... }
     local cacheFile = context.dataFolder .. "/workshop_cache.txt"
     local cache = util.JSONToTable(file.Read(cacheFile, "DATA") or "{}") or {}
 
@@ -19,6 +18,17 @@ function MODULE:Run(context)
 
             context.ignoreResources[addon.wsid] = true
             context.gamemodeAddons[addon.wsid] = scanned.isGamemode
+            context.manualAddons[addon.wsid] = scanned.manual
+
+            if scanned.scanResult then -- Compatibility with older caches
+                context.scanResult[addon.wsid] = scanned.scanResult
+            else
+                if scanned.hasResource then
+                    context.scanResult[addon.wsid] = { selected = true, type = "Resources" }
+                else
+                    context.scanResult[addon.wsid] = { selected = false, type = "Lua" }
+                end
+            end
         end
     end
 

--- a/lua/downloader/cache_save.lua
+++ b/lua/downloader/cache_save.lua
@@ -1,5 +1,5 @@
 local MODULE = {}
-MODULE.Order = 7
+MODULE.Order = 8
 
 local shouldDumpWorkshopCache = CreateConVar("downloader_dump_workshop_cache", 0, FCVAR_ARCHIVE, "Should dump the next Workshop resources scan into a txt file")
 
@@ -21,7 +21,6 @@ local function DumpWorkshopCache(context)
 end
 
 function MODULE:Run(context)
-    -- cache = { [number wsid] = { bool hasResource, string updated }, ... }
     local cacheFile = context.dataFolder .. "/workshop_cache.txt"
     local cache = {}
 
@@ -29,7 +28,9 @@ function MODULE:Run(context)
         cache[addon.wsid] = {
             hasResource = context.addonsToCache[addon.wsid] == true,
             updated = addon.updated,
-            isGamemode = context.gamemodeAddons[addon.wsid] == true
+            isGamemode = context.gamemodeAddons[addon.wsid] == true,
+            scanResult = context.scanResult[addon.wsid],
+            manual = context.manualAddons[addon.wsid]
         }
     end
 

--- a/lua/downloader/cache_save.lua
+++ b/lua/downloader/cache_save.lua
@@ -29,7 +29,6 @@ function MODULE:Run(context)
             hasResource = context.addonsToCache[addon.wsid] == true,
             updated = addon.updated,
             isGamemode = context.gamemodeAddons[addon.wsid] == true,
-            scanResult = context.scanResult[addon.wsid],
             manual = context.manualAddons[addon.wsid]
         }
     end

--- a/lua/downloader/gamemode_scanner.lua
+++ b/lua/downloader/gamemode_scanner.lua
@@ -43,6 +43,9 @@ function MODULE:Run(context)
                 if isCurrentGamemode ~= nil then
                     if isCurrentGamemode then
                         table.insert(context.usingAddons, addon)
+                        context.scanResult[addon.wsid] = { selected = true, type = "Current gamemode" }
+                    else
+                        context.scanResult[addon.wsid] = { selected = false, type = "Unused gamemode" }
                     end
 
                     -- Is probably a gamemode addon, resources should be ignored

--- a/lua/downloader/gui_handler.lua
+++ b/lua/downloader/gui_handler.lua
@@ -1,0 +1,45 @@
+local MODULE = {}
+MODULE.Order = 9
+
+local subContext = {}
+
+net.Receive("uwd_exchange_scan_result", function(len, ply)
+    local scanResult = table.Copy(subContext.scanResult)
+
+    for wsid, value in pairs(subContext.manualAddons) do
+        if scanResult[wsid] then
+            scanResult[wsid].cachedManual = value
+        end
+    end
+
+    scanResult = util.TableToJSON(scanResult)
+
+    net.Start("uwd_exchange_scan_result")
+    net.WriteString(scanResult) -- Lazy
+    net.Send(ply)
+end)
+
+net.Receive("uwd_set_manual_selection", function(len, ply)
+    if not ply:IsAdmin() then return end
+
+    local wsid = tonumber(net.ReadString())
+    local value = net.ReadBool()
+
+    local cacheFile = subContext.dataFolder .. "/workshop_cache.txt"
+    local cache = util.JSONToTable(file.Read(cacheFile, "DATA") or "{}") or {}
+
+    cache[wsid] = cache[wsid] or {}
+    cache[wsid].manual = value
+
+    subContext.manualAddons[wsid] = value
+
+    file.Write(cacheFile, util.TableToJSON(cache))
+end)
+
+function MODULE:Run(context)
+    subContext.scanResult = table.Copy(context.scanResult)
+    subContext.manualAddons = table.Copy(context.manualAddons)
+    subContext.dataFolder = context.dataFolder
+end
+
+return MODULE

--- a/lua/downloader/gui_handler.lua
+++ b/lua/downloader/gui_handler.lua
@@ -3,6 +3,55 @@ MODULE.Order = 9
 
 local subContext = {}
 
+-- Send huge binary
+local sendTab = {}
+local function SendData(chunksID, data, toPly)
+    local chunksSubID = SysTime()
+
+    local totalSize = string.len(data)
+    local chunkSize = 64000 -- ~64KB max
+    local totalChunks = math.ceil(totalSize / chunkSize)
+
+    -- 3 minutes to remove possible memory leaks
+    sendTab[chunksID] = chunksSubID
+    timer.Create(chunksID, 180, 1, function()
+        sendTab[chunksID] = nil
+    end)
+
+    for i = 1, totalChunks, 1 do
+        local startByte = chunkSize * (i - 1) + 1
+        local remaining = totalSize - (startByte - 1)
+        local endByte = remaining < chunkSize and (startByte - 1) + remaining or chunkSize * i
+        local chunk = string.sub(data, startByte, endByte)
+
+        timer.Simple(i * 0.1, function()
+            if sendTab[chunksID] ~= chunksSubID then return end
+
+            local isLastChunk = i == totalChunks
+
+            net.Start("uwd_exchange_scan_result")
+            net.WriteString(chunksID)
+            net.WriteUInt(sendTab[chunksID], 32)
+            net.WriteUInt(#chunk, 16)
+            net.WriteData(chunk, #chunk)
+            net.WriteBool(isLastChunk)
+            if SERVER then
+                if toPly then
+                    net.Send(toPly)
+                else
+                    net.Broadcast()
+                end
+            else
+                net.SendToServer()
+            end
+
+            if isLastChunk then
+                sendTab[chunksID] = nil
+            end
+        end)
+    end
+end
+
 net.Receive("uwd_exchange_scan_result", function(len, ply)
     local scanResult = table.Copy(subContext.scanResult)
 
@@ -12,11 +61,9 @@ net.Receive("uwd_exchange_scan_result", function(len, ply)
         end
     end
 
-    scanResult = util.TableToJSON(scanResult)
+    scanResult =  util.Compress(util.TableToJSON(scanResult))
 
-    net.Start("uwd_exchange_scan_result")
-    net.WriteString(scanResult) -- Lazy
-    net.Send(ply)
+    SendData(tostring(ply), scanResult, ply)
 end)
 
 net.Receive("uwd_set_manual_selection", function(len, ply)

--- a/lua/downloader/manual_loader.lua
+++ b/lua/downloader/manual_loader.lua
@@ -1,0 +1,27 @@
+local MODULE = {}
+MODULE.Order = 6
+
+function MODULE:Run(context)
+    local selectedManualAddons = {}
+
+    for k, addon in ipairs(context.addons) do
+        if context.manualAddons[addon.wsid] then
+            selectedManualAddons[addon.wsid] = addon
+        end
+    end
+
+    for key = #context.usingAddons, 1, -1 do
+        local addon = context.usingAddons[key]
+        if context.manualAddons[addon.wsid] == false then
+            table.remove(context.usingAddons, key)
+        elseif context.manualAddons[addon.wsid] == true then
+            selectedManualAddons[addon.wsid] = nil
+        end
+    end
+
+    for wsid, addon in pairs(selectedManualAddons) do
+        table.insert(context.usingAddons, addon)
+    end
+end
+
+return MODULE

--- a/lua/downloader/map_scanner.lua
+++ b/lua/downloader/map_scanner.lua
@@ -10,6 +10,9 @@ function MODULE:Run(context)
         if isMap then
             if file.Exists("maps/" .. currentMap  .. ".bsp", addon.title) then
                 table.insert(context.usingAddons, addon)
+                context.scanResult[addon.wsid] = { selected = true, type = "Current map" }
+            else
+                context.scanResult[addon.wsid] = { selected = false, type = "Map or map content" }
             end
 
             -- Is probably a map addon, resources should be ignored

--- a/lua/downloader/mounted_loader.lua
+++ b/lua/downloader/mounted_loader.lua
@@ -1,5 +1,5 @@
 local MODULE = {}
-MODULE.Order = 6
+MODULE.Order = 7
 
 function MODULE:Run(context)
     for _, usingAddon in ipairs(context.usingAddons) do

--- a/lua/downloader/resource_scanner.lua
+++ b/lua/downloader/resource_scanner.lua
@@ -35,6 +35,9 @@ function MODULE:Run(context)
             if hasResources then
                 table.insert(context.usingAddons, addon)
                 context.addonsToCache[addon.wsid] = true
+                context.scanResult[addon.wsid] = { selected = true, type = "Resources" }
+            else
+                context.scanResult[addon.wsid] = { selected = false, type = "Lua" }
             end
         end
     end

--- a/lua/downloader/telemetry.lua
+++ b/lua/downloader/telemetry.lua
@@ -4,7 +4,9 @@ MODULE.Order = 100
 local disableTelemetry = CreateConVar("downloader_disable_telemetry", 0, FCVAR_ARCHIVE, "Should disable telemetry report")
 
 function MODULE:Run(context)
-    do return end -- Remove this line when we get a working url
+
+    do return end -- Disabled
+
     if not disableTelemetry:GetBool() then
         local finished = SysTime()
 


### PR DESCRIPTION
CPanel
---

![image](https://user-images.githubusercontent.com/5098527/233275693-2a16814a-dcaf-4cac-9f2e-a220018a8b7d.png)

DFrame
---

"Select", "Ignored", "Rejoin" and "Restart" states:
- Thumbnail backgroud:
  - green = selected addon
  - lighter green = ignored addon
  -  yellow = manually added ws resource, will be downloaded once the player rejoins
  - red = ws resource that needs removal, the server needs to be restarted

First look - The panel using the filter "All":
- The panel size always grow to max 80% screen width and 90% screen height depending on exactly how many addons we can fit in this space;
- The scroll bar is refreshed after the filter is changed;
- The window is fully contained in an object called Browser
- We download Max 20 thumbnails per second from Workshop and gradually cache them;
- We load max ~66 thumbnails per second from the cache.

![image](https://user-images.githubusercontent.com/5098527/233273467-2bc93b21-4bc2-4c89-a250-db4f2053f9a6.png)

Panel - Filter "All", two addons manually selected (left click):
- The selected addons are already integrated with the cache system, being saved immediately.

![image](https://user-images.githubusercontent.com/5098527/233273603-a8825504-27e5-4a01-b2f9-a3c378319b26.png)

Filter dropdown::

![image](https://user-images.githubusercontent.com/5098527/233275993-9e83a1b6-6bbf-4cac-89ab-0035e6abeb92.png)

Alert messages:

![image](https://user-images.githubusercontent.com/5098527/233277959-85470c01-4582-4289-b8e2-25af796d2041.png)

![image](https://user-images.githubusercontent.com/5098527/233277992-a257c3cc-31da-40f7-976a-2d3efe6b35a4.png)

Detection types:
- Resources
- Lua
- Current gamemode
- Unused gamemode
- Current map
- Map or map content

![image](https://user-images.githubusercontent.com/5098527/233283371-3e8303ae-460c-4950-8b10-08abcbc10631.png)

Tooltips:

![image](https://user-images.githubusercontent.com/5098527/233284239-463e02ed-0eca-45a8-9b27-6817bc6068de.png)

![image](https://user-images.githubusercontent.com/5098527/233284466-ad891aca-a9e0-48db-954c-e34f24fb4ccb.png)

Right click on the first addon;

![image](https://user-images.githubusercontent.com/5098527/233274940-219acf35-847e-404a-a302-e685213897c4.png)

Filter "Ignored":

![image](https://user-images.githubusercontent.com/5098527/233273945-b0b6c290-381b-42cc-aadf-a335f005ead2.png)

Filter "Manual":

![image](https://user-images.githubusercontent.com/5098527/233274035-f48c7881-6c77-49c7-8557-2d827f0bc1ed.png)

Filter "Selected":

![image](https://user-images.githubusercontent.com/5098527/233274353-1eb236ed-88e5-4cce-b653-230104c72a9f.png)

Logic when selecting addons to "rejoin" and "restart" states and restarting the game:

![image](https://user-images.githubusercontent.com/5098527/233289518-00e03e23-3149-44a8-a8f0-c69c35daeb73.png)

Filter "All" - Game reloaded:
- "Manual" messages were added to the first elements.

![image](https://user-images.githubusercontent.com/5098527/233274576-a4cc43cd-930e-4151-8037-6adf294e7467.png)

Logic when clicking multiple times on an addon without restarting the server:

![image](https://user-images.githubusercontent.com/5098527/233281321-dabe7d88-ad30-4d55-9b76-eab5821c2a70.png)

![image](https://user-images.githubusercontent.com/5098527/233282141-d6f37eb1-9280-46f2-8c18-934bcdbf384b.png)

![image](https://user-images.githubusercontent.com/5098527/233282549-f0aeec21-ac3b-4610-baa8-222a748a022e.png)

![image](https://user-images.githubusercontent.com/5098527/233281409-68b6530c-ac30-42db-abaf-b605c9b28c78.png)
